### PR TITLE
Update to the latest bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ keywords = ["ffi", "libffi", "closure", "c"]
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.18"
+bindgen = "0.22"
 make-cmd = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -7,17 +7,18 @@ use std::process::Command;
 
 use make_cmd::make;
 
-const LIBFFI_DIR: &'static str     = "libffi";
+const LIBFFI_DIR: &'static str = "libffi";
 
 fn main() {
-    let out_dir   = env::var("OUT_DIR").unwrap();
+    let out_dir = env::var("OUT_DIR").unwrap();
 
     let build_dir = Path::new(LIBFFI_DIR);
-    let prefix    = Path::new(&out_dir).join("libffi-root");
-    let include   = Path::new(&prefix).join("lib")
-                                      .join("libffi-3.2.1")
-                                      .join("include");
-    let libdir    = Path::new(&prefix).join("lib");
+    let prefix = Path::new(&out_dir).join("libffi-root");
+    let include = Path::new(&prefix)
+        .join("lib")
+        .join("libffi-3.2.1")
+        .join("include");
+    let libdir = Path::new(&prefix).join("lib");
 
     fn run_command(which: &'static str, cmd: &mut Command) {
         assert!(cmd.status().expect(which).success(), which);
@@ -25,38 +26,38 @@ fn main() {
 
     // Generate configure, run configure, make, make install
     run_command("Generating configure",
-                Command::new("./autogen.sh")
-                        .current_dir(&build_dir));
+                Command::new("./autogen.sh").current_dir(&build_dir));
     run_command("Configuring libffi",
                 Command::new("./configure")
-                        .arg("--disable-docs")
-                        .arg("--prefix")
-                        .arg(prefix)
-                        .current_dir(&build_dir));
+                    .arg("--disable-docs")
+                    .arg("--prefix")
+                    .arg(prefix)
+                    .current_dir(&build_dir));
     run_command("Building libffi",
                 make()
-                        .arg("install")
-                        .current_dir(&build_dir));
+                    .arg("install")
+                    .current_dir(&build_dir));
 
     // Now run bindgen.
 
     let include_file = Path::new("include").join("include_ffi.h");
     let out_file = Path::new("src").join("generated.rs");
 
-    let mut builder = bindgen::Builder::default();
-    builder.header(include_file.display().to_string());
-    builder.clang_arg(format!("-I{}", include.display()));
-
-    let bindings = builder.generate().expect("
+    let builder = bindgen::Builder::default();
+    builder.header(include_file.display().to_string())
+        .clang_arg(format!("-I{}", include.display()))
+        .no_unstable_rust()
+        .generate()
+        .expect("
         **********
-        Bindgen generation failed. Please file a bug report.
+        Bindgen generation failed. Please file a bug \
+                 report.
         **********
-    ");
-    bindings.write_to_file(out_file.display().to_string())
-            .expect("bindgen output");
+        ")
+        .write_to_file(out_file.display().to_string())
+        .expect("bindgen output");
 
     // Cargo linking directives
     println!("cargo:rustc-link-lib=ffi");
     println!("cargo:rustc-link-search={}", libdir.display());
 }
-


### PR DESCRIPTION
This updates libffi to the latest bindgen release.  This fixed my build problem with size_t not found.  :+1:  I have rustfmt automatically run when I save a file which changed a few things in build.rs.  If you don't like that I can revert those.  