### PR TITLE
Have bindgen add default impls

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -47,6 +47,7 @@ fn main() {
     builder.header(include_file.display().to_string())
         .clang_arg(format!("-I{}", include.display()))
         .no_unstable_rust()
+        .derive_default(true)
         .generate()
         .expect("
         **********


### PR DESCRIPTION
I did a build against libffi-rs and bindgen wasn't output a default impl for ffi_cif.  This fixes that up