### PR TITLE
Fix linker error on Arch Linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,7 @@ fn main() {
                 Command::new("./configure")
                     .arg("--prefix")
                     .arg(prefix)
+                    .arg("--with-pic")
                     .current_dir(&build_dir));
     run_command("Building libffi",
                 make()


### PR DESCRIPTION
Since rustc builds a position independent executable on Linux, so all libraries linked to the executable must be Position Independent Code. However, since libffi is not explicitly built as PIC, linking fails on Arch Linux.
This pull request fixes this issue.
