### PR TITLE
avoid an unnecessary build and supress unavoidable warnings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 target
 Cargo.lock
-src/generated.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,5 +29,8 @@
 //!
 //! to your crate root.
 
-mod generated;
-pub use generated::*;
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(improper_ctypes)]
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));


### PR DESCRIPTION
Cargo rebuilds the project even if the source code has not been changed at all, because build.rs changes files in the project directory.
This pull request prevents an unnecessary rebuild by moving build_dir and generated.rs into OUT_DIR. Also, it suppresses unavoidable warnings.