### PR TITLE
link against a self-built static library instead of a system shared library.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -60,6 +60,6 @@ fn main() {
         .expect("bindgen output");
 
     // Cargo linking directives
-    println!("cargo:rustc-link-lib=ffi");
+    println!("cargo:rustc-link-lib=static=ffi");
     println!("cargo:rustc-link-search={}", libdir.display());
 }


### PR DESCRIPTION
A system shared library is linked instead of self-built static library because KIND of a rustc-link-lib manifest key is not specified. This pull request fixes this issue by specifying KIND option.