### PR TITLE
Update `bindgen` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ keywords = ["ffi", "libffi", "closure", "c"]
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.22"
+bindgen = "0.31.3"
 make-cmd = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -60,9 +60,8 @@ fn main() {
     let builder = bindgen::Builder::default();
     builder.header(include_file.display().to_string())
         .clang_arg(format!("-I{}", include.display()))
-        .no_unstable_rust()
         .derive_default(true)
-        .hide_type("max_align_t")
+        .blacklist_type("max_align_t")
         .generate()
         .expect("
         **********


### PR DESCRIPTION
The `no_unstable_rust` method has been removed and replaced with control over targeting specific Rust versions. The default is the latest Rust stable.

The `hide_type` method has been deprecated in favor of the `blacklist_type` method. They are the same, but `blacklist_type` matches the nomenclature used in the `bindgen` CLI flags.