### PR TITLE
add back system library searching, under a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ keywords = ["ffi", "libffi", "closure", "c"]
 [build-dependencies]
 bindgen = "0.31.3"
 make-cmd = "0.1"
+pkg-config = "0.3.13"
+
+[features]
+system = []
+


### PR DESCRIPTION
Adds the `"system"` feature, which, when enabled, uses `pkg-config` to search for a system installation.  This functionality is largely based on [what the crate did prior to the "automatic build" update](https://github.com/tov/libffi-sys-rs/blob/f9086f317b8c3fb35110b90bd4909e1f5a2d0e1a/build.rs).

#### Why even bother?

I am using this patch on an old high performance computing resource where everything is out of date, including autotools.  On that machine, I tried building newer autotools, but have been unsuccessful at getting them to work.

I will understand if you choose not to accept this patch on the basis that such old systems are not worth supporting.  But I would nonetheless appreciate you giving it consideration!

#### Why a feature?

I'm uncertain about what the conventions are for when to build/search in `-sys` crates; I notice that the author of the `pkg-config` crate (achrichton) tends to write `-sys` crates that search by default, and use building from source as a fallback when the search fails.  However, I implemented it as a feature for now in order to be backwards compatible.