### PR TITLE
Support building on Windows using MSYS and similar MinGW environments

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,24 +16,24 @@ environment:
   matrix:
     - TARGET: x86_64-pc-windows-gnu
       CHANNEL: nightly
-    - TARGET: x86_64-pc-windows-msvc
-      CHANNEL: nightly
     - TARGET: x86_64-pc-windows-gnu
-      CHANNEL: stable
-    - TARGET: x86_64-pc-windows-msvc
       CHANNEL: stable
 
 install:
   - curl -sSf -o rustup-init.exe https://win.rustup.rs
   - rustup-init.exe --default-host %TARGET% --default-toolchain %CHANNEL% -y
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - set PATH=C:\msys64\usr\bin;%PATH%
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S automake autoconf texinfo mingw-w64-x86_64-clang libtool"
   - rustc -Vv
   - cargo -V
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - git submodule update --init --recursive
 
 cache:
   - C:\Users\appveyor\.cargo
   - compiler\vendor
 
 test_script:
-  - cargo build --verbose
-  - cargo test
+  - C:\msys64\usr\bin\env MSYSTEM=MINGW64 C:\msys64\usr\bin\bash -lc 'cd $APPVEYOR_BUILD_FOLDER; cargo build --verbose'
+  - C:\msys64\usr\bin\env MSYSTEM=MINGW64 C:\msys64\usr\bin\bash -lc 'cd $APPVEYOR_BUILD_FOLDER; cargo test'

--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,10 @@ fn probe_and_link() -> IncludePaths {
     IncludePaths(libffi.include_paths)
 }
 
+fn run_command(which: &'static str, cmd: &mut Command) {
+    assert!(cmd.status().expect(which).success(), which);
+}
+
 fn build_and_link() -> IncludePaths {
     let out_dir = env::var("OUT_DIR").unwrap();
     let build_dir = Path::new(&out_dir).join("libffi-build");
@@ -47,10 +51,6 @@ fn build_and_link() -> IncludePaths {
         .join("include");
     let libdir = Path::new(&prefix).join("lib");
     let libdir64 = Path::new(&prefix).join("lib64");
-
-    fn run_command(which: &'static str, cmd: &mut Command) {
-        assert!(cmd.status().expect(which).success(), which);
-    }
 
     // Copy LIBFFI_DIR into build_dir to avoid an unnecessary build
     if let Err(e) = fs::remove_dir_all(&build_dir) {
@@ -64,14 +64,10 @@ fn build_and_link() -> IncludePaths {
                     .arg(&build_dir));
 
     // Generate configure, run configure, make, make install
-    run_command("Generating configure",
-                Command::new("./autogen.sh").current_dir(&build_dir));
-    run_command("Configuring libffi",
-                Command::new("./configure")
-                    .arg("--prefix")
-                    .arg(prefix)
-                    .arg("--with-pic")
-                    .current_dir(&build_dir));
+    autogen(&build_dir);
+
+    configure_libffi(prefix, &build_dir);
+
     run_command("Building libffi",
                 make()
                     .arg("install")
@@ -83,6 +79,62 @@ fn build_and_link() -> IncludePaths {
     println!("cargo:rustc-link-search={}", libdir64.display());
 
     IncludePaths(vec![include])
+}
+
+fn autogen(build_dir: &Path) {
+    let mut command = Command::new("sh");
+
+    command
+        .arg("autogen.sh")
+        .current_dir(&build_dir);
+
+    if cfg!(windows) {
+        // When building in MSYS2, not clearing the environment variables first
+        // results in `configure` being generated incorrectly. By clearing the
+        // variables first, then restoring PATH, we can ensure the correct file
+        // is generated.
+        command
+            .env_clear()
+            .env("PATH", env::var("PATH").unwrap());
+    }
+
+    run_command("Generating configure", &mut command);
+}
+
+fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
+    let mut command = Command::new("sh");
+
+    command.arg("configure")
+        .arg("--with-pic")
+        .current_dir(&build_dir);
+
+    if cfg!(windows) {
+        // When using MSYS2, OUT_DIR will be a Windows like path such as
+        // C:\foo\bar. Unfortunately, the various scripts used for building
+        // libffi do not like such a path, so we have to turn this into a Unix
+        // like path such as /c/foo/bar.
+        //
+        // This code assumes the path only uses : for the drive letter, and only
+        // uses \ as a component separator. It will likely break for file paths
+        // that include a :.
+        let mut msys_prefix = prefix
+            .to_str()
+            .unwrap()
+            .replace(":\\", "/")
+            .replace("\\", "/");
+
+        msys_prefix.insert(0, '/');
+
+        command
+            .arg("--prefix")
+            .arg(msys_prefix);
+    } else {
+        command
+            .arg("--prefix")
+            .arg(prefix);
+    }
+
+    run_command("Configuring libffi", &mut command);
 }
 
 fn generate_bindings(include_paths: IncludePaths) {
@@ -100,7 +152,7 @@ fn generate_bindings(include_paths: IncludePaths) {
         .generate()
         .expect("
         **********
-        Bindgen generation failed. 
+        Bindgen generation failed.
         Note that Bindgen requires clang to be installed. See the Bindgen documentation for more information:
         https://rust-lang-nursery.github.io/rust-bindgen/requirements.html
 


### PR DESCRIPTION
This PR makes various changes to the build script so that this crate can be
built on Windows using MSYS2 and other MinGW based environments (e.g.  Cygwin
should also work).

Building using MSVC is not supported at this time, as I could not get this to
work. There are various forks that use CMake, but they are either based on older
versions with the CMake configuration not supporting newer releases, only
support a very limited set of targets, or don't work for some other reason.

To make this happen we have to fix the prefix used for libffi, as libffi under
MSYS2 _does not_ like regular Windows paths (e.g. `C:\foo`), and Cargo happens
to pass such as path in the `OUT_DIR` environment variable.

This PR includes the necessary changes to get the tests running on AppVeyor,
including the removal of testing MSVC environments, as these won't work. Getting
things to build on AppVeyor requires starting a proper MSYS2 bash shell. This is
a bit annoying, but I couldn't come up with an easier way of doing this.