### PR TITLE
Update bundled libffi to 3.3 and build without documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,3 @@ matrix:
 notifications:
   email:
     on_success: never
-
-addons:
-  apt:
-    packages:
-      - texinfo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - rustup-init.exe --default-host %TARGET% --default-toolchain %CHANNEL% -y
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - set PATH=C:\msys64\usr\bin;%PATH%
-  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S automake autoconf texinfo mingw-w64-x86_64-clang libtool"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S automake autoconf mingw-w64-x86_64-clang libtool"
   - rustc -Vv
   - cargo -V
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/build.rs
+++ b/build.rs
@@ -103,6 +103,7 @@ fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
 
     command.arg("configure")
         .arg("--with-pic")
+        .arg("--disable-docs")
         .current_dir(&build_dir);
 
     if cfg!(windows) {

--- a/build.rs
+++ b/build.rs
@@ -45,10 +45,7 @@ fn build_and_link() -> IncludePaths {
     let out_dir = env::var("OUT_DIR").unwrap();
     let build_dir = Path::new(&out_dir).join("libffi-build");
     let prefix = Path::new(&out_dir).join("libffi-root");
-    let include = Path::new(&prefix)
-        .join("lib")
-        .join("libffi-3.2.1")
-        .join("include");
+    let include = Path::new(&prefix).join("include");
     let libdir = Path::new(&prefix).join("lib");
     let libdir64 = Path::new(&prefix).join("lib64");
 


### PR DESCRIPTION
This pull request makes two changes:

1. It updates the bundled libffi to the latest 3.3 version
2. It disables the building of documentation when building libffi, which removes the dependency on texinfo.