### PR TITLE
Bump bindgen dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.20.0
+  - 1.30.0
 
 dist: trusty
 sudo: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ffi", "libffi", "closure", "c"]
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.31.3"
+bindgen = "^0.49"
 make-cmd = "0.1"
 pkg-config = "0.3.13"
 


### PR DESCRIPTION
The previous version was quite old. The dependency on clang-sys would
also prevent depending crates from using a newer version, as Windows
does not allow linking to clang using different clang-sys versions. This
would produce errors such as:

    error: multiple packages link to native library `clang`, but a native library can be linked only once
    package `clang-sys v0.21.2`
        ... which is depended on by `bindgen v0.31.3`
        ... which is depended on by `libffi-sys v0.6.3`
        ... which is depended on by `inko v0.3.0 (C:\projects\inko\vm)`
    links to native library `clang`
    package `clang-sys v0.28.0`
        ... which is depended on by `bindgen v0.49.0`
        ... which is depended on by `wepoll-sys v1.0.2`
        ... which is depended on by `inko v0.3.0 (C:\projects\inko\vm)`
    also links to native library `clang`
    make: *** [Makefile:30: test] Error 101
    make: Leaving directory '/c/projects/inko/vm'