### PR TITLE
Fix “operation not supported” error.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -59,7 +59,7 @@ fn build_and_link() -> IncludePaths {
     }
     run_command("Copying libffi into the build directory",
                 Command::new("cp")
-                    .arg("-a")
+                    .arg("-R")
                     .arg(LIBFFI_DIR)
                     .arg(&build_dir));
 


### PR DESCRIPTION
I am trying to compile this on a (file)system which apparently lacks support for copying extended attributes. Using the `-R` flag should be enough, since it still preserves the file mode.