### PR TITLE
Update bindgen to 0.51

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ffi", "libffi", "closure", "c"]
 [dependencies]
 
 [build-dependencies]
-bindgen = "^0.49"
+bindgen = "0.51"
 make-cmd = "0.1"
 pkg-config = "0.3.13"
 


### PR DESCRIPTION
A bug <https://github.com/rust-lang/rust-bindgen/pull/1627> causes compilation failure in nightly compiler.