### PR TITLE
Unset DESTDIR when installing libffi

### DIFF
--- a/build/not_msvc.rs
+++ b/build/not_msvc.rs
@@ -28,7 +28,10 @@ pub fn build_and_link() {
 
     run_command(
         "Building libffi",
-        make_cmd::make().arg("install").current_dir(&build_dir),
+        make_cmd::make()
+            .env_remove("DESTDIR")
+            .arg("install")
+            .current_dir(&build_dir),
     );
 
     // Cargo linking directives


### PR DESCRIPTION
When DESTDIR is set, libffi will try to install itself into that
directory, breaking the cargo build process. Clearing all environment
variables is not an option, as environments such as MSYS may depend on
an unspecified number of environment variables.
